### PR TITLE
Add as sfnetwork methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,11 +38,12 @@ Imports:
   tidygraph,
   utils
 Suggests:
-  dplyr,
-  fansi,
-  ggplot2,
-  knitr,
-  testthat
+    dplyr,
+    fansi,
+    ggplot2,
+    knitr,
+    testthat,
+    spatstat
 RoxygenNote: 7.1.0
 VignetteBuilder: knitr
 URL: https://luukvdmeer.github.io/sfnetworks/, https://github.com/luukvdmeer/sfnetworks

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 S3method("st_crs<-",sfnetwork)
 S3method("st_geometry<-",sfnetwork)
 S3method(as_sfnetwork,default)
+S3method(as_sfnetwork,psp)
 S3method(as_sfnetwork,sf)
 S3method(as_sfnetwork,sfNetwork)
 S3method(as_sfnetwork,sfnetwork)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 S3method("st_crs<-",sfnetwork)
 S3method("st_geometry<-",sfnetwork)
 S3method(as_sfnetwork,default)
+S3method(as_sfnetwork,linnet)
 S3method(as_sfnetwork,psp)
 S3method(as_sfnetwork,sf)
 S3method(as_sfnetwork,sfNetwork)

--- a/R/sfnetwork.R
+++ b/R/sfnetwork.R
@@ -3,7 +3,7 @@
 #' \code{sfnetwork} is a tidy data structure for geospatial networks. It extends
 #' the graph manipulation functionalities of the
 #' \code{\link[tidygraph]{tidygraph-package}} package into the domain of
-#' geospatial networks, where the nodes and optionally also the edges are 
+#' geospatial networks, where the nodes and optionally also the edges are
 #' embedded in geographical space, and enables to apply the spatial analytical
 #' function from the \code{\link[sf:sf]{sf-package}} directly to the network.
 #'
@@ -35,7 +35,7 @@
 #' constructing the network. These checks guarantee a valid spatial network
 #' structure. For the nodes, this means that they all should have \code{POINT}
 #' geometries. In the case of spatially explicit edges, it is also checked that
-#' all edges have \code{LINESTRING} geometries, nodes and edges have the same 
+#' all edges have \code{LINESTRING} geometries, nodes and edges have the same
 #' CRS and boundary points of edges match their corresponding node coordinates.
 #' These checks are important, but also time consuming. If you are already sure
 #' your input data meet the requirements, the checks are unneccesary and can be
@@ -48,7 +48,7 @@
 #'
 #' @importFrom tidygraph tbl_graph
 #' @export
-sfnetwork = function(nodes, edges, directed = TRUE, edges_as_lines = NULL, 
+sfnetwork = function(nodes, edges, directed = TRUE, edges_as_lines = NULL,
                      force = FALSE, ...) {
   # Automatically set edges_as_lines if not given.
   if (is.null(edges_as_lines)) {
@@ -129,7 +129,7 @@ nodes_to_sf = function(nodes, ...) {
 #'
 #' @param x object to be converted into an \code{\link{sfnetwork}} object.
 #'
-#' @param ... arguments passed on to the \code{\link{sfnetwork}} construction 
+#' @param ... arguments passed on to the \code{\link{sfnetwork}} construction
 #' function.
 #'
 #' @return An object of class \code{\link{sfnetwork}}.
@@ -198,6 +198,24 @@ as_sfnetwork.tbl_graph = function(x, ...) {
   args$directed = if (dir_missing) is_directed(x) else args$directed
   # Call the sfnetwork construction function.
   do.call("sfnetwork", args)
+}
+
+#' @name as_sfnetwork
+#' @importFrom sf st_as_sf st_collection_extract
+#' @export
+as_sfnetwork.psp = function(x, ...) {
+  # I think that the easiest method for transforming a Line Segment Pattern
+  # (psp) object into sfnetwork format is to transform it into sf format and
+  # then apply the usual methods.
+  x_sf = sf::st_as_sf(x)
+
+  # x_sf is an sf object composed by 1 POLYGON (the window of the psp object)
+  # and several LINESTRINGs (the line segments). I'm not sure if and how we can
+  # use the window object so I will extract only the LINESTRINGs.
+  x_linestring = sf::st_collection_extract(x_sf, "LINESTRING")
+
+  # apply as_sfnetwork.sf
+  as_sfnetwork(x_linestring)
 }
 
 #' @importFrom sf st_as_sf st_crs st_geometry

--- a/R/sfnetwork.R
+++ b/R/sfnetwork.R
@@ -203,6 +203,16 @@ as_sfnetwork.tbl_graph = function(x, ...) {
 #' @name as_sfnetwork
 #' @importFrom sf st_as_sf st_collection_extract
 #' @export
+#' @examples
+#' # Examples for psp method
+#' if (require(spatstat)) {
+#' set.seed(42)
+#' test_psp = psp(runif(10), runif(10), runif(10), runif(10), window=owin())
+#' plot(test_psp, main = "spatstat input")
+#' test_psp_as_sfnetwork = as_sfnetwork(test_psp)
+#' plot(test_psp_as_sfnetwork, main = "sfnetworks output")
+#' }
+#'
 as_sfnetwork.psp = function(x, ...) {
   # I think that the easiest method for transforming a Line Segment Pattern
   # (psp) object into sfnetwork format is to transform it into sf format and
@@ -215,7 +225,28 @@ as_sfnetwork.psp = function(x, ...) {
   x_linestring = sf::st_collection_extract(x_sf, "LINESTRING")
 
   # apply as_sfnetwork.sf
-  as_sfnetwork(x_linestring)
+  as_sfnetwork(x_linestring, ...)
+}
+
+#' @name as_sfnetwork
+#' @export
+#' @examples
+#' # Examples for linnet method
+#' if (require(spatstat)) {
+#' plot(simplenet, main = "spatstat input")
+#' simplenet_as_sfnetwork = as_sfnetwork(simplenet)
+#' plot(simplenet_as_sfnetwork, main = "sfnetworks output")
+#' }
+#'
+as_sfnetwork.linnet = function(x, ...) {
+  # IMO the easiest approach is the same as for psp objects, i.e. converting the
+  # linnet object into a psp format and then applying the corresponding method.
+  if (!requireNamespace("spatstat", quietly = TRUE)) {
+    stop("package spatstat required, please install it first")
+  }
+
+  x_psp = spatstat::as.psp(x)
+  as_sfnetwork(x_psp, ...)
 }
 
 #' @importFrom sf st_as_sf st_crs st_geometry

--- a/man/as_sfnetwork.Rd
+++ b/man/as_sfnetwork.Rd
@@ -7,6 +7,7 @@
 \alias{as_sfnetwork.sfNetwork}
 \alias{as_sfnetwork.sfnetwork}
 \alias{as_sfnetwork.tbl_graph}
+\alias{as_sfnetwork.psp}
 \title{Convert a foreign object to an sfnetwork object}
 \usage{
 as_sfnetwork(x, ...)
@@ -20,11 +21,13 @@ as_sfnetwork(x, ...)
 \method{as_sfnetwork}{sfnetwork}(x, ...)
 
 \method{as_sfnetwork}{tbl_graph}(x, ...)
+
+\method{as_sfnetwork}{psp}(x, ...)
 }
 \arguments{
 \item{x}{object to be converted into an \code{\link{sfnetwork}} object.}
 
-\item{...}{arguments passed on to the \code{\link{sfnetwork}} construction 
+\item{...}{arguments passed on to the \code{\link{sfnetwork}} construction
 function.}
 }
 \value{

--- a/man/as_sfnetwork.Rd
+++ b/man/as_sfnetwork.Rd
@@ -8,6 +8,7 @@
 \alias{as_sfnetwork.sfnetwork}
 \alias{as_sfnetwork.tbl_graph}
 \alias{as_sfnetwork.psp}
+\alias{as_sfnetwork.linnet}
 \title{Convert a foreign object to an sfnetwork object}
 \usage{
 as_sfnetwork(x, ...)
@@ -23,6 +24,8 @@ as_sfnetwork(x, ...)
 \method{as_sfnetwork}{tbl_graph}(x, ...)
 
 \method{as_sfnetwork}{psp}(x, ...)
+
+\method{as_sfnetwork}{linnet}(x, ...)
 }
 \arguments{
 \item{x}{object to be converted into an \code{\link{sfnetwork}} object.}
@@ -38,4 +41,21 @@ Convert a given object into an object of class \code{\link{sfnetwork}}.
 If an object can be read by \code{\link[tidygraph]{as_tbl_graph}} and the
 nodes can be read by \code{\link[sf]{st_as_sf}}, it is automatically
 supported by sfnetworks.
+}
+\examples{
+# Examples for psp method
+if (require(spatstat)) {
+test_psp = psp(runif(10), runif(10), runif(10), runif(10), window=owin())
+plot(test_psp, main = "spatstat input")
+test_psp_as_sfnetwork = as_sfnetwork(test_psp)
+plot(test_psp_as_sfnetwork, main = "sfnetworks output")
+}
+
+# Examples for linnet method
+if (require(spatstat)) {
+plot(simplenet, main = "spatstat input")
+simplenet_as_sfnetwork = as_sfnetwork(simplenet)
+plot(simplenet_as_sfnetwork, main = "sfnetworks output")
+}
+
 }

--- a/man/sfnetwork.Rd
+++ b/man/sfnetwork.Rd
@@ -42,7 +42,7 @@ otherwise. Defaults to \code{NULL}.}
 constructing the network. These checks guarantee a valid spatial network
 structure. For the nodes, this means that they all should have \code{POINT}
 geometries. In the case of spatially explicit edges, it is also checked that
-all edges have \code{LINESTRING} geometries, nodes and edges have the same 
+all edges have \code{LINESTRING} geometries, nodes and edges have the same
 CRS and boundary points of edges match their corresponding node coordinates.
 These checks are important, but also time consuming. If you are already sure
 your input data meet the requirements, the checks are unneccesary and can be
@@ -58,7 +58,7 @@ An object of class \code{sfnetwork}.
 \code{sfnetwork} is a tidy data structure for geospatial networks. It extends
 the graph manipulation functionalities of the
 \code{\link[tidygraph]{tidygraph-package}} package into the domain of
-geospatial networks, where the nodes and optionally also the edges are 
+geospatial networks, where the nodes and optionally also the edges are
 embedded in geographical space, and enables to apply the spatial analytical
 function from the \code{\link[sf:sf]{sf-package}} directly to the network.
 }


### PR DESCRIPTION
Hi! I added `as_sfnetwork` methods for `psp` and `linnet` objects for #41. I had to include `spatstat` to Suggests since I had to convert `linnet` objects into `psp` format. 

I also checked `rmangal` format but I'm not so sure how to include it. The code is trivial since we can transform `mgNetwork` objects into `tidygraph` format but I'm not 100% sure that it's the right conversion for creating a spatial network.