### PR TITLE
Include GEOS 3.7 version dependency for st_reverse()

### DIFF
--- a/tests/testthat/test_geometry.R
+++ b/tests/testthat/test_geometry.R
@@ -21,6 +21,7 @@ test_that("st_set_geometry gives an error when replacing edges geometry CRS", {
 
 test_that("st_set_geometry gives an error when replacing edges geometry
           endpoints", {
+  skip_if_not(sf::sf_extSoftVersion()["GEOS"] >= "3.7.0")
   net = roxel %>% as_sfnetwork()
   new_geom = sf::st_geometry(sf::st_reverse(roxel))
   expect_error(activate(net, "edges") %>% sf::st_set_geometry(new_geom))

--- a/tests/testthat/test_plot.R
+++ b/tests/testthat/test_plot.R
@@ -1,4 +1,3 @@
-library(ggplot2)
 net_exp = as_sfnetwork(roxel)
 net_imp = as_sfnetwork(roxel, edges_as_lines = FALSE)
 
@@ -8,14 +7,16 @@ test_that("plot accepts sfnetworks with spatially implicit edges", {
   expect_silent(plot(net_imp, draw_lines = FALSE))
 })
 test_that("autplot returns a ggplot with two layers", {
-  g = autoplot(net_exp)
+  skip_if_not_installed("ggplot2")
+  g = ggplot2::autoplot(net_exp)
   expect_s3_class(g, "gg")
   expect_s3_class(g, "ggplot")
   expect_equal(length(g$layers), 2)
 })
 test_that("autoplot shows a message when implicit edges are passed", {
+  skip_if_not_installed("ggplot2", "3.0.0")
   expect_message(
-    autoplot(net_imp),
+    ggplot2::autoplot(net_imp),
     "Spatially implicit edges are drawn as lines"
   )
 })

--- a/tests/testthat/test_sf.R
+++ b/tests/testthat/test_sf.R
@@ -50,6 +50,7 @@ dirnet = as_sfnetwork(edge)
 undirnet = as_sfnetwork(edge, directed = FALSE)
 
 test_that("st_reverse returns valid networks", {
+  skip_if_not(sf::sf_extSoftVersion()["GEOS"] >= "3.7.0")
   reversed_D <- suppressWarnings(st_reverse(activate(dirnet, "edges")))
   reversed_U <- st_reverse(activate(undirnet, "edges"))
   expect_null(sfnetworks:::require_valid_network_structure(reversed_D))
@@ -58,6 +59,7 @@ test_that("st_reverse returns valid networks", {
 
 test_that("st_reverse gives a warning when nodes are active, keeping the same
           coordinates order and from/to columns", {
+  skip_if_not(sf::sf_extSoftVersion()["GEOS"] >= "3.7.0")
   expect_warning(reversed <- st_reverse(dirnet), "no effect on nodes")
   expect_setequal(st_coordinates(reversed), st_coordinates(dirnet))
   expect_setequal(
@@ -76,6 +78,7 @@ test_that("st_reverse gives a warning when nodes are active, keeping the same
 
 test_that("st_reverse reverses the order of the to/from columns and the
           order of the coordinates for directed networks", {
+  skip_if_not(sf::sf_extSoftVersion()["GEOS"] >= "3.7.0")
   expect_warning(
     reversed <- st_reverse(activate(dirnet, "edges")),
     "st_reverse swaps columns"
@@ -100,6 +103,7 @@ test_that("st_reverse reverses the order of the to/from columns and the
 
 test_that("st_reverse reverses the order of the coordinates for
           undirected networks", {
+ skip_if_not(sf::sf_extSoftVersion()["GEOS"] >= "3.7.0")
  reversed <- st_reverse(activate(undirnet, "edges"))
  expect_equal(
    st_coordinates(reversed)[1, ],

--- a/vignettes/preprocess_and_clean.Rmd
+++ b/vignettes/preprocess_and_clean.Rmd
@@ -14,6 +14,7 @@ knitr::opts_chunk$set(
   comment = "#>"
 )
 knitr::opts_knit$set(global.par = TRUE)
+geos37 = sf::sf_extSoftVersion()["GEOS"] >= "3.7.0"
 ```
 
 ```{r plot, echo=FALSE, results='asis'}
@@ -81,9 +82,9 @@ In `sfnetworks` you can create directed and undirected networks. In directed one
 
 Unfortunately, neither `igraph` nor `tidygraph` provides an interface for such networks. Therefore, the only way to deal with this is to create a directed network but first *duplicate* and *reverse* all edge linestrings that can be traveled both ways.
 
-See the small example below, where we have three lines with one-way information stored in a *oneway* column. One of the lines is a one-way street, the other two are not. By duplicating and reversing the two linestrings that are not one-way streets, we create a directed network that correctly models our situation.
+See the small example below, where we have three lines with one-way information stored in a *oneway* column. One of the lines is a one-way street, the other two are not. By duplicating and reversing the two linestrings that are not one-way streets, we create a directed network that correctly models our situation. Note that reversing linestrings using `sf::st_reverse()` only works with GEOS >= 3.7.
 
-```{r}
+```{r, eval = geos37}
 p1 = st_point(c(7, 51))
 p2 = st_point(c(7, 52))
 p3 = st_point(c(8, 52))
@@ -95,8 +96,7 @@ l3 = st_sfc(st_linestring(c(p3, p2)))
 edges = st_as_sf(c(l1, l2, l3), crs = 4326)
 edges$oneway = c(TRUE, FALSE, FALSE)
 edges
-```
-```{r}
+
 duplicates = edges[!edges$oneway, ]
 reversed_duplicates = st_reverse(duplicates)
 

--- a/vignettes/structure.Rmd
+++ b/vignettes/structure.Rmd
@@ -14,6 +14,7 @@ knitr::opts_chunk$set(
   comment = "#>"
 )
 knitr::opts_knit$set(global.par = TRUE)
+geos37 = sf::sf_extSoftVersion()["GEOS"] >= "3.7.0"
 ```
 
 ```{r plot, echo=FALSE, results='asis'}
@@ -273,9 +274,9 @@ net %>%
   plot(vertex.color = "black", main = "Nodes without geometries")
 ```
 
-Geometries can be replaced also by using [geometry unary operations](https://r-spatial.github.io/sf/reference/geos_unary.html), as long as they don't break the valid spatial network structure. In practice this means that only `sf::st_reverse()` and `sf::st_simplify()` are supported. When calling `sf::st_reverse()` on the edges of a directed network, not only the geometries will be reversed, but the *from* and *to* columns of the edges will be swapped as well. In the case of undirected networks these columns remain unchanged, since the terms *from* and *to* don't have a meaning in undirected networks and can be used interchangeably.
+Geometries can be replaced also by using [geometry unary operations](https://r-spatial.github.io/sf/reference/geos_unary.html), as long as they don't break the valid spatial network structure. In practice this means that only `sf::st_reverse()` and `sf::st_simplify()` are supported. When calling `sf::st_reverse()` on the edges of a directed network, not only the geometries will be reversed, but the *from* and *to* columns of the edges will be swapped as well. In the case of undirected networks these columns remain unchanged, since the terms *from* and *to* don't have a meaning in undirected networks and can be used interchangeably. Note that reversing linestrings using `sf::st_reverse()` only works with GEOS >= 3.7.
 
-```{r}
+```{r, eval = geos37}
 as_sfnetwork(roxel, directed = TRUE) %>%
   activate("edges") %>%
   st_reverse()


### PR DESCRIPTION
Fix #140.

I am unsure of the success of this approach since testing on Solaris is not straightforward. This PR will most likely fail the checks since it needs the `spatstat` adaptation done in https://github.com/luukvdmeer/sfnetworks/pull/138
