### PR TITLE
Reassign CRS to `roxel` in tests to comply with different GDAL and PROJ versions

### DIFF
--- a/R/attrs.R
+++ b/R/attrs.R
@@ -16,6 +16,12 @@
 #' and \code{agr} (the attribute-geometry-relationships).
 #'
 #' @examples
+#' ## Need to add this line to set roxel CRS again
+#' ## to comply with different PROJ versions
+#' if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+#'   sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+#' }
+#'
 #' net = as_sfnetwork(roxel)
 #' sf_attr(net, "agr", active = "edges")
 #' sf_attr(net, "sf_column", active = "nodes")

--- a/R/bbox.R
+++ b/R/bbox.R
@@ -13,6 +13,12 @@
 #' @details See \code{\link[sf]{st_bbox}} for details.
 #'
 #' @examples
+#' ## Need to add this line to set roxel CRS again
+#' ## to comply with different PROJ versions
+#' if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+#'   sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+#' }
+#'
 #' library(sf)
 #'
 #' # Create a network.

--- a/R/blend.R
+++ b/R/blend.R
@@ -38,6 +38,12 @@
 #' even if you only want to blend points that intersect the line.
 #'
 #' @examples
+#' ## Need to add this line to set roxel CRS again
+#' ## to comply with different PROJ versions
+#' if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+#'   sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+#' }
+#'
 #' library(sf, quietly = TRUE)
 #'
 #' # Create a network and a set of points to blend.

--- a/R/edge.R
+++ b/R/edge.R
@@ -23,6 +23,12 @@ NULL
 #' the edge startpoint and the edge endpoint. Calculated with
 #' \code{\link[lwgeom]{st_geod_azimuth}}. Requires a geographic CRS.
 #' @examples
+#' ## Need to add this line to set roxel CRS again
+#' ## to comply with different PROJ versions
+#' if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+#'   sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+#' }
+#'
 #' library(sf, quietly = TRUE)
 #' library(tidygraph, quietly = TRUE)
 #'
@@ -153,6 +159,12 @@ straight_line_distance = function(x) {
 #' 'as-the-crow-flies' distance, and not on distances over the network.
 #'
 #' @examples
+#' ## Need to add this line to set roxel CRS again
+#' ## to comply with different PROJ versions
+#' if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+#'   sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+#' }
+#'
 #' library(sf, quietly = TRUE)
 #' library(tidygraph, quietly = TRUE)
 #'

--- a/R/join.R
+++ b/R/join.R
@@ -18,6 +18,11 @@
 #' @return The joined networks as an object of class \code{\link{sfnetwork}}.
 #'
 #' @examples
+#' ## Need to add this line to set roxel CRS again
+#' ## to comply with different PROJ versions
+#' if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+#'   sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+#' }
 #' library(sf, quietly = TRUE)
 #'
 #' node1 = st_point(c(0, 0))

--- a/R/morphers.R
+++ b/R/morphers.R
@@ -41,6 +41,12 @@
 #' \href{https://luukvdmeer.github.io/sfnetworks/articles/morphers.html}{spatial morphers}.
 #'
 #' @examples
+#' ## Need to add this line to set roxel CRS again
+#' ## to comply with different PROJ versions
+#' if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+#'   sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+#' }
+#'
 #' library(sf, quietly = TRUE)
 #' library(tidygraph, quietly = TRUE)
 #'

--- a/R/node.R
+++ b/R/node.R
@@ -120,6 +120,12 @@ get_coords = function(x, value) {
 #' with edge lengths as weights argument.
 #'
 #' @examples
+#' ## Need to add this line to set roxel CRS again
+#' ## to comply with different PROJ versions
+#' if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+#'   sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+#' }
+#'
 #' library(sf, quietly = TRUE)
 #' library(tidygraph, quietly = TRUE)
 #'

--- a/R/paths.R
+++ b/R/paths.R
@@ -78,6 +78,12 @@
 #' \code{node_paths}, while \code{'shortest'} returns both.
 #'
 #' @examples
+#' ## Need to add this line to set roxel CRS again
+#' ## to comply with different PROJ versions
+#' if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+#'   sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+#' }
+#'
 #' library(sf, quietly = TRUE)
 #' library(tidygraph, quietly = TRUE)
 #'
@@ -296,6 +302,12 @@ get_all_simple_paths = function(x, from, to, ...) {
 #' nearest node, these features are considered duplicates.
 #'
 #' @examples
+#' ## Need to add this line to set roxel CRS again
+#' ## to comply with different PROJ versions
+#' if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+#'   sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+#' }
+#'
 #' library(sf, quietly = TRUE)
 #' library(tidygraph, quietly = TRUE)
 #'

--- a/R/plot.R
+++ b/R/plot.R
@@ -17,9 +17,9 @@
 #' and others.
 #'
 #' @examples
-#' ## Need to add this line to set Roxel CRS again
+#' ## This line sets roxel CRS again
 #' ## to comply with different PROJ versions
-#' st_crs(roxel) = "EPSG:4326"
+#' sf::st_crs(roxel) = "EPSG:4326"
 #'
 #' oldpar = par(no.readonly = TRUE)
 #' par(mar = c(1,1,1,1), mfrow = c(1,1))

--- a/R/plot.R
+++ b/R/plot.R
@@ -17,9 +17,11 @@
 #' and others.
 #'
 #' @examples
-#' ## This line sets roxel CRS again
+#' ## Need to add this line to set roxel CRS again
 #' ## to comply with different PROJ versions
-#' sf::st_crs(roxel) = "EPSG:4326"
+#' if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+#'   sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+#' }
 #'
 #' oldpar = par(no.readonly = TRUE)
 #' par(mar = c(1,1,1,1), mfrow = c(1,1))

--- a/R/plot.R
+++ b/R/plot.R
@@ -17,6 +17,10 @@
 #' and others.
 #'
 #' @examples
+#' ## Need to add this line to set Roxel CRS again
+#' ## to comply with different PROJ versions
+#' st_crs(roxel) = "EPSG:4326"
+#'
 #' oldpar = par(no.readonly = TRUE)
 #' par(mar = c(1,1,1,1), mfrow = c(1,1))
 #' net = as_sfnetwork(roxel)

--- a/R/roxel.R
+++ b/R/roxel.R
@@ -5,6 +5,10 @@
 #' from OpenStreetMap, querying by key = 'highway'. The topology is cleaned with
 #' the v.clean tool in GRASS GIS.
 #'
+#' Dataset was created using PROJ>=7.0.0 and hence needs to get tje CRS reassigned
+#' when working with other PROJ versions as:
+#' \code{sf::st_crs(roxel) = sf::st_crs('EPSG:4326')}
+#'
 #' @format An object of class \code{\link[sf]{sf}} with \code{LINESTRING}
 #' geometries, containing 851 features and three columns:
 #' \describe{

--- a/R/sf.R
+++ b/R/sf.R
@@ -44,6 +44,12 @@ is.sfg = function(x) {
 #' @name sf
 #'
 #' @examples
+#' ## Need to add this line to set roxel CRS again
+#' ## to comply with different PROJ versions
+#' if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+#'   sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+#' }
+#'
 #' library(sf, quietly = TRUE)
 #'
 #' net = as_sfnetwork(roxel)

--- a/R/sfnetwork.R
+++ b/R/sfnetwork.R
@@ -224,6 +224,12 @@ as_sfnetwork.default = function(x, ...) {
 #' the given features geometries form the nodes. They will be connected by
 #' edges sequentially. Hence, point 1 to point 2, point 2 to point 3, etc.
 #' @examples
+#' ## Need to add this line to set roxel CRS again
+#' ## to comply with different PROJ versions
+#' if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+#'   sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+#' }
+#'
 #' # From an sf object.
 #' library(sf, quietly = TRUE)
 #'

--- a/R/tibble.R
+++ b/R/tibble.R
@@ -28,6 +28,12 @@
 #' @name as_tibble
 #'
 #' @examples
+#' ## Need to add this line to set roxel CRS again
+#' ## to comply with different PROJ versions
+#' if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+#'   sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+#' }
+#'
 #' library(tibble, quietly = TRUE)
 #'
 #' net = as_sfnetwork(roxel)

--- a/man/as.linnet.Rd
+++ b/man/as.linnet.Rd
@@ -5,7 +5,7 @@
 \alias{as.linnet.sfnetwork}
 \title{Convert a sfnetwork into a linnet}
 \usage{
-as.linnet.sfnetwork(X, ...)
+\method{as.linnet}{sfnetwork}(X, ...)
 }
 \arguments{
 \item{X}{An object of class \code{\link{sfnetwork}} with a projected CRS.}

--- a/man/as.linnet.Rd
+++ b/man/as.linnet.Rd
@@ -5,7 +5,7 @@
 \alias{as.linnet.sfnetwork}
 \title{Convert a sfnetwork into a linnet}
 \usage{
-\method{as.linnet}{sfnetwork}(X, ...)
+as.linnet.sfnetwork(X, ...)
 }
 \arguments{
 \item{X}{An object of class \code{\link{sfnetwork}} with a projected CRS.}

--- a/man/as_sfnetwork.Rd
+++ b/man/as_sfnetwork.Rd
@@ -57,6 +57,12 @@ edges sequentially. Hence, point 1 to point 2, point 2 to point 3, etc.
 }}
 
 \examples{
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 # From an sf object.
 library(sf, quietly = TRUE)
 

--- a/man/as_tibble.Rd
+++ b/man/as_tibble.Rd
@@ -36,6 +36,12 @@ using the corresponding \code{\link[sf]{sf}} method if present. When using
 as a user, you can disable this behaviour by setting \code{spatial = FALSE}.
 }
 \examples{
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(tibble, quietly = TRUE)
 
 net = as_sfnetwork(roxel)

--- a/man/plot.sfnetwork.Rd
+++ b/man/plot.sfnetwork.Rd
@@ -26,9 +26,11 @@ as can be found in \code{sf}, \code{tmap}, \code{ggplot2}, \code{ggspatial},
 and others.
 }
 \examples{
-## This line sets roxel CRS again
+## Need to add this line to set roxel CRS again
 ## to comply with different PROJ versions
-sf::st_crs(roxel) = "EPSG:4326"
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
 
 oldpar = par(no.readonly = TRUE)
 par(mar = c(1,1,1,1), mfrow = c(1,1))

--- a/man/plot.sfnetwork.Rd
+++ b/man/plot.sfnetwork.Rd
@@ -26,6 +26,10 @@ as can be found in \code{sf}, \code{tmap}, \code{ggplot2}, \code{ggspatial},
 and others.
 }
 \examples{
+## Need to add this line to set Roxel CRS again
+## to comply with different PROJ versions
+st_crs(roxel) = "EPSG:4326"
+
 oldpar = par(no.readonly = TRUE)
 par(mar = c(1,1,1,1), mfrow = c(1,1))
 net = as_sfnetwork(roxel)

--- a/man/plot.sfnetwork.Rd
+++ b/man/plot.sfnetwork.Rd
@@ -26,9 +26,9 @@ as can be found in \code{sf}, \code{tmap}, \code{ggplot2}, \code{ggspatial},
 and others.
 }
 \examples{
-## Need to add this line to set Roxel CRS again
+## This line sets roxel CRS again
 ## to comply with different PROJ versions
-st_crs(roxel) = "EPSG:4326"
+sf::st_crs(roxel) = "EPSG:4326"
 
 oldpar = par(no.readonly = TRUE)
 par(mar = c(1,1,1,1), mfrow = c(1,1))

--- a/man/roxel.Rd
+++ b/man/roxel.Rd
@@ -25,4 +25,9 @@ Roxel, a neighborhood in the city of Münster, Germany. The data are taken
 from OpenStreetMap, querying by key = 'highway'. The topology is cleaned with
 the v.clean tool in GRASS GIS.
 }
+\details{
+Dataset was created using PROJ>=7.0.0 and hence needs to get tje CRS reassigned
+when working with other PROJ versions as:
+\code{sf::st_crs(roxel) = sf::st_crs('EPSG:4326')}
+}
 \keyword{datasets}

--- a/man/sf.Rd
+++ b/man/sf.Rd
@@ -113,6 +113,12 @@ See the \code{\link[sf]{sf}} documentation for details.
 See the \code{\link[sf]{sf}} documentation.
 }
 \examples{
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf, quietly = TRUE)
 
 net = as_sfnetwork(roxel)

--- a/man/sf_attr.Rd
+++ b/man/sf_attr.Rd
@@ -28,6 +28,12 @@ sf attributes include \code{sf_column} (the name of the sf column)
 and \code{agr} (the attribute-geometry-relationships).
 }
 \examples{
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 net = as_sfnetwork(roxel)
 sf_attr(net, "agr", active = "edges")
 sf_attr(net, "sf_column", active = "nodes")

--- a/man/spatial_edge_measures.Rd
+++ b/man/spatial_edge_measures.Rd
@@ -59,6 +59,12 @@ boundary nodes of an edge, as calculated by \code{\link[sf]{st_distance}}.
 }}
 
 \examples{
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf, quietly = TRUE)
 library(tidygraph, quietly = TRUE)
 

--- a/man/spatial_edge_predicates.Rd
+++ b/man/spatial_edge_predicates.Rd
@@ -77,6 +77,12 @@ Note that \code{edge_is_within_distance} is a wrapper around the
 'as-the-crow-flies' distance, and not on distances over the network.
 }
 \examples{
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf, quietly = TRUE)
 library(tidygraph, quietly = TRUE)
 

--- a/man/spatial_morphers.Rd
+++ b/man/spatial_morphers.Rd
@@ -214,6 +214,12 @@ Returns a \code{morphed_sfnetwork} containing a single element of class
 }}
 
 \examples{
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf, quietly = TRUE)
 library(tidygraph, quietly = TRUE)
 

--- a/man/spatial_node_predicates.Rd
+++ b/man/spatial_node_predicates.Rd
@@ -64,6 +64,12 @@ distances over the network, use \code{\link[tidygraph]{node_distance_to}}
 with edge lengths as weights argument.
 }
 \examples{
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf, quietly = TRUE)
 library(tidygraph, quietly = TRUE)
 

--- a/man/st_network_bbox.Rd
+++ b/man/st_network_bbox.Rd
@@ -23,6 +23,12 @@ bounding box of the nodes and edges in the network.
 See \code{\link[sf]{st_bbox}} for details.
 }
 \examples{
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf)
 
 # Create a network.

--- a/man/st_network_blend.Rd
+++ b/man/st_network_blend.Rd
@@ -49,6 +49,12 @@ recommended to set the tolerance to a very small number (for example 1e-5)
 even if you only want to blend points that intersect the line.
 }
 \examples{
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf, quietly = TRUE)
 
 # Create a network and a set of points to blend.

--- a/man/st_network_cost.Rd
+++ b/man/st_network_cost.Rd
@@ -94,6 +94,12 @@ nearest node will be reduced to one by selecting only the first of these
 features.
 }
 \examples{
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf, quietly = TRUE)
 library(tidygraph, quietly = TRUE)
 

--- a/man/st_network_join.Rd
+++ b/man/st_network_join.Rd
@@ -27,6 +27,11 @@ the networks. The \code{from} and \code{to} columns in the edge data are
 updated such that they match the new node indices of the resulting network.
 }
 \examples{
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
 library(sf, quietly = TRUE)
 
 node1 = st_point(c(0, 0))

--- a/man/st_network_paths.Rd
+++ b/man/st_network_paths.Rd
@@ -93,6 +93,12 @@ see the \code{\link[igraph]{shortest_paths}} or
 \code{\link[igraph]{all_simple_paths}} documentation pages.
 }
 \examples{
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf, quietly = TRUE)
 library(tidygraph, quietly = TRUE)
 

--- a/tests/testthat/test_bbox.R
+++ b/tests/testthat/test_bbox.R
@@ -1,5 +1,10 @@
-library(sf)
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
 
+library(sf)
 test_that("st_network_bbox combines the bounding box of nodes and edges", {
   rdm_rox = roxel[sample(nrow(roxel), 50), ]
   net = as_sfnetwork(rdm_rox)

--- a/tests/testthat/test_blend.R
+++ b/tests/testthat/test_blend.R
@@ -1,3 +1,9 @@
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf)
 library(igraph)
 library(dplyr)

--- a/tests/testthat/test_crs.R
+++ b/tests/testthat/test_crs.R
@@ -1,7 +1,9 @@
 library(sf)
+## Need to add this line to set Roxel CRS again
+## to comply with different PROJ versions
+st_crs(roxel) = "EPSG:4326"
 
 test_that("st_set_crs sets the crs for edges and nodes", {
-  skip_if_not(sf::sf_extSoftVersion()["PROJ"] >= "7.0.0")
   net = as_sfnetwork(roxel) %>%
     st_set_crs(NA)
   expect_equal(st_crs(activate(net, "nodes")), st_crs(activate(net, "edges")))

--- a/tests/testthat/test_crs.R
+++ b/tests/testthat/test_crs.R
@@ -1,8 +1,10 @@
-library(sf)
-## Need to add this line to set Roxel CRS again
+## Need to add this line to set roxel CRS again
 ## to comply with different PROJ versions
-st_crs(roxel) = "EPSG:4326"
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
 
+library(sf)
 test_that("st_set_crs sets the crs for edges and nodes", {
   net = as_sfnetwork(roxel) %>%
     st_set_crs(NA)
@@ -10,7 +12,6 @@ test_that("st_set_crs sets the crs for edges and nodes", {
 })
 
 test_that("st_transform changes crs for edges and nodes", {
-  skip_if_not(sf::sf_extSoftVersion()["PROJ"] >= "7.0.0")
   net = as_sfnetwork(roxel) %>%
     st_transform(3857)
   expect_equal(st_crs(activate(net, "nodes")), st_crs(activate(net, "edges")))

--- a/tests/testthat/test_crs.R
+++ b/tests/testthat/test_crs.R
@@ -1,12 +1,14 @@
 library(sf)
 
 test_that("st_set_crs sets the crs for edges and nodes", {
+  skip_if_not(sf::sf_extSoftVersion()["PROJ"] >= "7.0.0")
   net = as_sfnetwork(roxel) %>%
     st_set_crs(NA)
   expect_equal(st_crs(activate(net, "nodes")), st_crs(activate(net, "edges")))
 })
 
 test_that("st_transform changes crs for edges and nodes", {
+  skip_if_not(sf::sf_extSoftVersion()["PROJ"] >= "7.0.0")
   net = as_sfnetwork(roxel) %>%
     st_transform(3857)
   expect_equal(st_crs(activate(net, "nodes")), st_crs(activate(net, "edges")))

--- a/tests/testthat/test_edges_nodes.R
+++ b/tests/testthat/test_edges_nodes.R
@@ -1,3 +1,9 @@
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf)
 library(dplyr)
 library(igraph)

--- a/tests/testthat/test_geometry.R
+++ b/tests/testthat/test_geometry.R
@@ -15,6 +15,7 @@ test_that("st_set_geometry gives an error when replacing edges geometry
 })
 
 test_that("st_set_geometry gives an error when replacing edges geometry CRS", {
+  skip_if_not(sf::sf_extSoftVersion()["PROJ"] >= "7.0.0")
   net = roxel %>% as_sfnetwork()
   new_geom = st_geometry(st_transform(roxel, 3035))
   expect_error(activate(net, "edges") %>% sf::st_set_geometry(new_geom))

--- a/tests/testthat/test_geometry.R
+++ b/tests/testthat/test_geometry.R
@@ -1,3 +1,7 @@
+## Need to add this line to set Roxel CRS again
+## to comply with different PROJ versions
+sf::st_crs(roxel) = "EPSG:4326"
+
 test_that("st_set_geometry(NULL) for activated nodes changes the class to
           tbl_graph", {
   net = roxel %>% as_sfnetwork()
@@ -15,7 +19,6 @@ test_that("st_set_geometry gives an error when replacing edges geometry
 })
 
 test_that("st_set_geometry gives an error when replacing edges geometry CRS", {
-  skip_if_not(sf::sf_extSoftVersion()["PROJ"] >= "7.0.0")
   net = roxel %>% as_sfnetwork()
   new_geom = st_geometry(st_transform(roxel, 3035))
   expect_error(activate(net, "edges") %>% sf::st_set_geometry(new_geom))

--- a/tests/testthat/test_geometry.R
+++ b/tests/testthat/test_geometry.R
@@ -1,6 +1,8 @@
-## Need to add this line to set Roxel CRS again
+## Need to add this line to set roxel CRS again
 ## to comply with different PROJ versions
-sf::st_crs(roxel) = "EPSG:4326"
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
 
 test_that("st_set_geometry(NULL) for activated nodes changes the class to
           tbl_graph", {

--- a/tests/testthat/test_join.R
+++ b/tests/testthat/test_join.R
@@ -1,3 +1,9 @@
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf)
 library(igraph)
 library(dplyr)

--- a/tests/testthat/test_morphers.R
+++ b/tests/testthat/test_morphers.R
@@ -1,8 +1,11 @@
-skip_if_not(sf::sf_extSoftVersion()["PROJ"] >= "7.0.0")
 library(sf)
 library(tidygraph)
 library(igraph)
 library(dplyr)
+
+## Need to add this line to set Roxel CRS again
+## to comply with different PROJ versions
+st_crs(roxel) = "EPSG:4326"
 
 # Toy sfnetwork
 p1 = st_point(c(0, 1))

--- a/tests/testthat/test_morphers.R
+++ b/tests/testthat/test_morphers.R
@@ -1,11 +1,13 @@
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf)
 library(tidygraph)
 library(igraph)
 library(dplyr)
-
-## Need to add this line to set Roxel CRS again
-## to comply with different PROJ versions
-st_crs(roxel) = "EPSG:4326"
 
 # Toy sfnetwork
 p1 = st_point(c(0, 1))

--- a/tests/testthat/test_morphers.R
+++ b/tests/testthat/test_morphers.R
@@ -1,3 +1,4 @@
+skip_if_not(sf::sf_extSoftVersion()["PROJ"] >= "7.0.0")
 library(sf)
 library(tidygraph)
 library(igraph)

--- a/tests/testthat/test_paths.R
+++ b/tests/testthat/test_paths.R
@@ -1,11 +1,13 @@
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf)
 library(dplyr)
 library(igraph)
 library(tidygraph)
-
-## Need to add this line to set Roxel CRS again
-## to comply with different PROJ versions
-st_crs(roxel) = "EPSG:4326"
 
 net = as_sfnetwork(roxel, directed = FALSE) %>%
   st_transform(3035)

--- a/tests/testthat/test_paths.R
+++ b/tests/testthat/test_paths.R
@@ -1,8 +1,12 @@
-skip_if_not(sf::sf_extSoftVersion()["PROJ"] >= "7.0.0")
 library(sf)
 library(dplyr)
 library(igraph)
 library(tidygraph)
+
+## Need to add this line to set Roxel CRS again
+## to comply with different PROJ versions
+st_crs(roxel) = "EPSG:4326"
+
 net = as_sfnetwork(roxel, directed = FALSE) %>%
   st_transform(3035)
 sub1 = net %>%

--- a/tests/testthat/test_paths.R
+++ b/tests/testthat/test_paths.R
@@ -1,3 +1,4 @@
+skip_if_not(sf::sf_extSoftVersion()["PROJ"] >= "7.0.0")
 library(sf)
 library(dplyr)
 library(igraph)

--- a/tests/testthat/test_plot.R
+++ b/tests/testthat/test_plot.R
@@ -1,3 +1,9 @@
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 net_exp = as_sfnetwork(roxel)
 net_imp = as_sfnetwork(roxel, edges_as_lines = FALSE)
 

--- a/tests/testthat/test_sf.R
+++ b/tests/testthat/test_sf.R
@@ -1,3 +1,5 @@
+skip_if_not(sf::sf_extSoftVersion()["PROJ"] >= "7.0.0")
+
 library(sf)
 library(dplyr)
 

--- a/tests/testthat/test_sf.R
+++ b/tests/testthat/test_sf.R
@@ -1,7 +1,8 @@
-skip_if_not(sf::sf_extSoftVersion()["PROJ"] >= "7.0.0")
-
 library(sf)
 library(dplyr)
+## Need to add this line to set Roxel CRS again
+## to comply with different PROJ versions
+st_crs(roxel) = "EPSG:4326"
 
 rect = roxel %>%
   st_union() %>%

--- a/tests/testthat/test_sf.R
+++ b/tests/testthat/test_sf.R
@@ -1,8 +1,11 @@
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(sf)
 library(dplyr)
-## Need to add this line to set Roxel CRS again
-## to comply with different PROJ versions
-st_crs(roxel) = "EPSG:4326"
 
 rect = roxel %>%
   st_union() %>%

--- a/tests/testthat/test_sfnetworks.R
+++ b/tests/testthat/test_sfnetworks.R
@@ -1,3 +1,9 @@
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(igraph)
 library(sf)
 library(dplyr)

--- a/tests/testthat/test_spatstat.R
+++ b/tests/testthat/test_spatstat.R
@@ -1,5 +1,8 @@
 if (requireNamespace("spatstat") && packageVersion("spatstat") >= "2.0.1") {
   library(spatstat)
+  ## Need to add this line to set Roxel CRS again
+  ## to comply with different PROJ versions
+  st_crs(roxel) = "EPSG:4326"
   test_that("Converting sfnetwork to linnet works with projected coords", {
     roxel_sfn <- as_sfnetwork(roxel) %>% st_transform(3857)
     # I added suppressWarnings since as.linnet returns a few warning messages
@@ -14,5 +17,4 @@ if (requireNamespace("spatstat") && packageVersion("spatstat") >= "2.0.1") {
     expect_error(as.linnet(roxel_sfn))
   })
 }
-
 

--- a/tests/testthat/test_spatstat.R
+++ b/tests/testthat/test_spatstat.R
@@ -1,8 +1,10 @@
 if (requireNamespace("spatstat") && packageVersion("spatstat") >= "2.0.1") {
-  library(spatstat)
-  ## Need to add this line to set Roxel CRS again
+  ## Need to add this line to set roxel CRS again
   ## to comply with different PROJ versions
-  st_crs(roxel) = "EPSG:4326"
+  if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+    sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+  }
+  library(spatstat)
   test_that("Converting sfnetwork to linnet works with projected coords", {
     roxel_sfn <- as_sfnetwork(roxel) %>% st_transform(3857)
     # I added suppressWarnings since as.linnet returns a few warning messages

--- a/tests/testthat/test_tidygraph.R
+++ b/tests/testthat/test_tidygraph.R
@@ -1,3 +1,9 @@
+## Need to add this line to set roxel CRS again
+## to comply with different PROJ versions
+if(sf::sf_extSoftVersion()["PROJ"] < "7.0.0"){
+  sf::st_crs(roxel) = sf::st_crs('EPSG:4326')
+}
+
 library(tidygraph)
 test_that("Morphing works for sfnetwork and tbl_graph objects", {
   expect_s3_class(


### PR DESCRIPTION
I am hoping this will avoid errors on the CRAN checks. I am trying to check on rhub, will report if this succeeds.