### PR TITLE
Add packageStartupMessage related to problems with old PROJ + new CRS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,7 +37,7 @@
 * The default of the `Inf_as_NaN` argument in `edge_circuity()` is changed from `TRUE` to `FALSE`, to better fit with the change mentioned above, and to make sure no changes to R defaults are made without the user explicitly specifying them.
 * Whenever there are multiple matches when spatially joining information to the nodes of a network with `sf::st_join()`, only the information of the first match is now joined. Before, this used to throw an error. Refs [#108](https://github.com/luukvdmeer/sfnetworks/discussions/108)
 * Removal of the morphed_sfnetwork method for `sf::st_geometry<-`, since geometries should not be replaced in a morphed state.
-* The warning '.. assumes attributes are constant over geometries' is now only raised when not all attribute-geometry relationships are set to 'constant'. Refs [#123](https://github.com/luukvdmeer/sfnetworks/discussions/123)
+* The warning '.. assumes attributes are constant over geometries' is now only raised when not all attribute-geometry relationships are set to 'constant'. Refs [#123](https://github.com/luukvdmeer/sfnetworks/issues/123)
 * Bug fixes:
   - The attribute-geometry relationships of edge attributes are now preserved during network construction. Fixes [#123](https://github.com/luukvdmeer/sfnetworks/issues/123)
   - `st_network_blend()` now correctly blends points that are very close to the network. Fixes [#98](https://github.com/luukvdmeer/sfnetworks/issues/98)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -87,7 +87,7 @@ s3_register = function(generic, class, method = NULL) {
 }
 
 .onAttach = function(libname, pkgname) {
-  if (sf::sf_extSoftVersion()["PROJ"] < "7.0.0" || sf::sf_extSoftVersion()["proj.4"] < "7.0.0") {
+  if (sf::sf_extSoftVersion()["PROJ"] < "6.0.0" || sf::sf_extSoftVersion()["proj.4"] < "6.0.0") {
     packageStartupMessage(paste0(
       'Warning: It seems that you are using an old version of PROJ. If you ',
       'use the built-in roxel dataset, please remember to reassign its CRS, ',

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -85,4 +85,15 @@ s3_register = function(generic, class, method = NULL) {
 
   invisible()
 }
+
+.onAttach = function(libname, pkgname) {
+  if (sf::sf_extSoftVersion()["PROJ"] < "7.0.0" || sf::sf_extSoftVersion()["proj.4"] < "7.0.0") {
+    packageStartupMessage(paste0(
+      'Warning: It seems that you are using an old version of PROJ. If you ',
+      'use the built-in roxel dataset, please remember to reassign its CRS, ',
+      'i.e. sf::st_crs(roxel) = sf::st_crs("EPSG:4326"), before running any ',
+      'example.'
+    ))
+  }
+}
 # nocov end

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 <!-- badges: start -->
 
 [![R build status](https://github.com/luukvdmeer/sfnetworks/workflows/R-CMD-check/badge.svg)](https://github.com/luukvdmeer/sfnetworks/actions)
-[![Codecov test coverage](https://codecov.io/gh/luukvdmeer/sfnetworks/branch/master/graph/badge.svg)](https://codecov.io/gh/luukvdmeer/sfnetworks/)
+[![Codecov test coverage](https://codecov.io/gh/luukvdmeer/sfnetworks/branch/master/graph/badge.svg)](https://app.codecov.io/gh/luukvdmeer/sfnetworks)
 [![CRAN](http://www.r-pkg.org/badges/version/sfnetworks)](https://cran.r-project.org/package=sfnetworks)
-[![Downloads](https://cranlogs.r-pkg.org/badges/sfnetworks?color=orange)](https://cran.r-project.org/package=sfnetworks)
+[![Downloads](https://cranlogs.r-pkg.org/badges/sfnetworks)](https://cran.r-project.org/package=sfnetworks)
 <!-- badges: end -->
 
 `sfnetworks` is an R package for analysis of geospatial networks. It connects the functionalities of the `tidygraph` package for network analysis and the `sf` package for spatial data science.

--- a/man/sfnetworks-package.Rd
+++ b/man/sfnetworks-package.Rd
@@ -8,10 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
 
-Provides a tidy approach to spatial network
-    analysis, in the form of classes and functions that enable a seamless
-    interaction between the network analysis package 'tidygraph' and the
-    spatial analysis package 'sf'.
+Provides a tidy approach to spatial network analysis, in the form of classes and functions that enable a seamless interaction between the network analysis package 'tidygraph' and the spatial analysis package 'sf'.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
See discussion in #190. 

Output from my (old) VM: 

``` r
sf::sf_extSoftVersion()
#>           GEOS           GDAL         proj.4 GDAL_with_GEOS     USE_PROJ_H 
#>        "3.7.1"        "2.4.2"        "5.2.0"         "true"        "false"
library(sfnetworks)
#> Warning: It seems that you are using an old version of PROJ. If you use the built-in roxel dataset, please remember to reassign its CRS, i.e. sf::st_crs(roxel) = sf::st_crs("EPSG:4326"), before running any example.
```

<sup>Created on 2021-12-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

Fell free to change the message