### PR TITLE
Check extSoftVersion of proj.4 only 

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -87,7 +87,7 @@ s3_register = function(generic, class, method = NULL) {
 }
 
 .onAttach = function(libname, pkgname) {
-  if (sf::sf_extSoftVersion()["PROJ"] < "6.0.0" || sf::sf_extSoftVersion()["proj.4"] < "6.0.0") {
+  if (sf::sf_extSoftVersion()["proj.4"] < "6.0.0") {
     packageStartupMessage(paste0(
       'Warning: It seems that you are using an old version of PROJ. If you ',
       'use the built-in roxel dataset, please remember to reassign its CRS, ',


### PR DESCRIPTION
Ref #200. The problem is that `sf_extSoftVersion()["PROJ"]` is [defined](https://github.com/r-spatial/sf/commit/9aa8a6222873d6c181464d226e9bad83d17a55d1#diff-1e8c7b94d7dc2f0d70c4e457124889b5637ba42993015643e5d80be52e3ec912) only for `sf >= 1.0` and we do not enforce that version of  `sf` so that subset operation returns NA. Looking at the [sf repository](https://github.com/r-spatial/sf/blob/2e36433bdeeaee80bfeaf7763998ba629e69bb89/R/init.R#L66-L71),  `sf_extSoftVersion()["proj.4"]` and `sf_extSoftVersion()["PROJ"]` returns the same value, so we can simply check `sf_extSoftVersion()["proj.4"]` (although I'm not sure if that will be always true). See also https://github.com/luukvdmeer/sfnetworks/issues/198#issuecomment-1003943394.
