### PR TITLE
fix `desc()` syntax

### DIFF
--- a/vignettes/sfn05_morphers.Rmd
+++ b/vignettes/sfn05_morphers.Rmd
@@ -194,7 +194,7 @@ net %>%
   mutate(bc_dir = centrality_betweenness()) %>%
   unmorph() %>%
   mutate(bc_diff = bc_dir - bc_undir) %>%
-  arrange(bc_diff, desc())
+  arrange(desc(bc_diff))
 ```
 
 ### to_spatial_explicit


### PR DESCRIPTION
We're about to release dplyr 1.0.8 and we have identified an issue with one of this package vignette. 

````
# sfnetworks

<details>

* Version: 0.5.4
* GitHub: https://github.com/luukvdmeer/sfnetworks
* Source code: https://github.com/cran/sfnetworks
* Date/Publication: 2021-12-17 09:00:02 UTC
* Number of recursive dependencies: 139

Run `cloud_details(, "sfnetworks")` for more info

</details>

## Newly broken

*   checking re-building of vignette outputs ... WARNING
    ```
    Error(s) in re-building vignettes:
    --- re-building ‘sfn01_structure.Rmd’ using rmarkdown
    Linking to GEOS 3.8.0, GDAL 3.0.4, PROJ 6.3.1; sf_use_s2() is TRUE
    
    Attaching package: 'tidygraph'
    
    The following object is masked from 'package:stats':
    
        filter
    
    ...
    Quitting from lines 190-198 (sfn05_morphers.Rmd) 
    Error: processing vignette 'sfn05_morphers.Rmd' failed with diagnostics:
    [1m[22m`desc()` must be called with exactly one argument.
    --- failed re-building ‘sfn05_morphers.Rmd’
    
    SUMMARY: processing the following file failed:
      ‘sfn05_morphers.Rmd’
    
    Error: Vignette re-building failed.
    Execution halted
    ```
````

Please consider this fix. 