### PR TITLE
Rewrite plot.sfnetwork

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -42,24 +42,29 @@
 #' @importFrom sf st_geometry
 #' @export
 plot.sfnetwork = function(x, draw_lines = TRUE, ...) {
+  # The following function was modified after the discussion in #226
+
+  # Extract and setup extra args
   dots = list(...)
-  # Get geometries of nodes.
-  nsf = pull_node_geom(x)
-  # Combine node geometries with edge geometries if needed.
-  use_edges = TRUE
-  if (! has_explicit_edges(x)) {
-    if (draw_lines) {
-      x = explicitize_edges(x)
-    } else {
-      use_edges = FALSE
-    }
-  }
-  dots$x = if (use_edges) c(nsf, pull_edge_geom(x)) else nsf
-  # Use pch of 20 by default.
   pch_missing = is.null(dots$pch)
   dots$pch = if (pch_missing) 20 else dots$pch
-  # Plot.
-  do.call(plot, dots)
+
+  # Get geometries of nodes.
+  nsf = pull_node_geom(x)
+  # Plot the nodes
+  do.call(plot, c(list(nsf), dots))
+
+  # If necessary, plot also the edges
+  if (has_explicit_edges(x) || draw_lines) {
+    x = explicitize_edges(x)
+    esf = pull_edge_geom(x)
+
+    dots$add = TRUE
+    do.call(plot, c(list(esf), dots))
+  }
+
+  # The end
+  invisible()
 }
 
 #' Plot sfnetwork geometries with ggplot2


### PR DESCRIPTION
Ref #226. I'm not 100% that this is an exact replica of the old function, but I tested some examples (i.e. the ones documented in the [docs](https://luukvdmeer.github.io/sfnetworks/reference/plot.sfnetwork.html)) and I get identical results: 

``` r
library(sfnetworks)
oldpar = par(no.readonly = TRUE)
par(mar = c(1,1,1,1), mfrow = c(1,1))
net = as_sfnetwork(roxel)
plot(net)
```

![](https://i.imgur.com/fnNBE2O.png)

``` r
# When lines are spatially implicit.
par(mar = c(1,1,1,1), mfrow = c(1,2))
net = as_sfnetwork(roxel, edges_as_lines = FALSE)
plot(net)
plot(net, draw_lines = FALSE)
```

![](https://i.imgur.com/jUQR5ty.png)

``` r
# Changing default settings.
par(mar = c(1,1,1,1), mfrow = c(1,1))
plot(net, col = 'blue', pch = 18, lwd = 1, cex = 2)
```

![](https://i.imgur.com/SejqbzV.png)

``` r
# Add grid and axis
par(mar = c(2.5,2.5,1,1))
plot(net, graticule = TRUE, axes = TRUE)
```

![](https://i.imgur.com/FC7DCLA.png)

<sup>Created on 2022-09-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Moreover, it looks like this new approach is quite faster than the current one: 

``` r
remotes::install_cran("sfnetworks", quiet = TRUE)
library(sf)
#> Linking to GEOS 3.9.1, GDAL 3.2.1, PROJ 7.2.1; sf_use_s2() is TRUE
library(tidygraph)
#> 
#> Attaching package: 'tidygraph'
#> The following object is masked from 'package:stats':
#> 
#>     filter
library(sfnetworks)

set.seed(1)
my_graph <- play_geometry(n = 5000, radius = 0.025)
my_sfn <- as_sfnetwork(my_graph, coords = c("x", "y"))
#> Checking if spatial network structure is valid...
#> Spatial network structure is valid
system.time(plot(my_sfn))

#>    user  system elapsed 
#>   15.79    1.17   17.31

plot_sfnetwork = function(x, draw_lines = TRUE, ...) {
  dots = list(...)
  pch_missing = is.null(dots$pch)
  dots$pch = if (pch_missing) 20 else dots$pch
  nsf = sfnetworks:::pull_node_geom(x)
  do.call(plot, c(list(nsf), dots))
  if (sfnetworks:::has_explicit_edges(x) || draw_lines) {
    x = sfnetworks:::explicitize_edges(x)
    esf = sfnetworks:::pull_edge_geom(x)
    dots$add = TRUE
    do.call(plot, c(list(esf), dots))
  }
  invisible()
}
system.time(plot_sfnetwork(my_sfn))

#>    user  system elapsed 
#>    2.47    1.04    3.55
```
<sup>Created on 2022-09-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>



