### PR TITLE
Modify `to_spatial_contracted` test and code. Fix #243

### DIFF
--- a/R/morphers.R
+++ b/R/morphers.R
@@ -148,7 +148,8 @@ to_spatial_contracted = function(x, ..., simplify = FALSE,
   # --> Use its original geometry.
   # For each node that was contracted:
   # --> Use the centroid of the geometries of the group members.
-  new_node_geoms = st_geometry(nodes)[!duplicated(all_group_idxs)]
+  new_node_idxs = sapply(new_nodes$.tidygraph_node_index, "[[", 1)
+  new_node_geoms = st_geometry(nodes)[new_node_idxs]
   get_centroid = function(i) {
     comb = st_combine(st_geometry(i))
     suppressWarnings(st_centroid(comb))

--- a/tests/testthat/test_morphers.R
+++ b/tests/testthat/test_morphers.R
@@ -36,7 +36,7 @@ rect = st_buffer(A, dist = 300, endCapStyle = "SQUARE")
 # Create network from lines
 lines = c(l1, l2, l3, l4, l5, l6, l7)
 net_l = as_sfnetwork(lines) %>%
-  mutate(rdm = sample(1:3, 8, replace = T))
+  mutate(cluster = c(1, 3, 2, 3, 1, 1, 1, 3))
 net_i = as_sfnetwork(lines, edges_as_lines = F)
 
 # Create directed Roxel network
@@ -48,7 +48,7 @@ net_u = as_sfnetwork(roxel, directed = FALSE) %>%
   st_transform(3035)
 
 # Perform spatial contraction
-cont_l = convert(net_l, to_spatial_contracted, rdm)
+cont_l = convert(net_l, to_spatial_contracted, cluster)
 
 # Morph to spatial directed
 dire_u = convert(net_u, to_spatial_directed)


### PR DESCRIPTION
1. Update `test_morphers.m`, specifying clusters for `to_spatial_contracted()` so as to catch the issue with mismatching node geometry (Ref. #243)
2. Modify `to_spatial_contracted()` in `morphers.m` to ensure that the order of the updated node geometries matches the order of the updated nodes, even if there are non-duplicated, non-sorted clustering values.

Pull request to `main` branch because `develop` branch missing.