### PR TITLE
Fix spatstat related code

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        R: [ 'release', 'devel' ]
+        R: [ 'release' ]
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
@@ -23,11 +23,10 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.R }}
-          use-public-rspm: false
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          cache-version: 2
           extra-packages: rcmdcheck
 
       - uses: r-lib/actions/check-r-package@v2

--- a/R/spatstat.R
+++ b/R/spatstat.R
@@ -15,7 +15,7 @@ check_spatstat = function(pkg) {
     )
   } else {
     spst_ver = try(packageVersion("spatstat"), silent = TRUE)
-    if (!inherits(spst_ver, "try-error") && spst_ver < 2.0-0) {
+    if (!inherits(spst_ver, "try-error") && spst_ver < "2.0-0") {
       stop(
         "You have an old version of spatstat which is incompatible with ",
         pkg,

--- a/man/as.linnet.Rd
+++ b/man/as.linnet.Rd
@@ -5,7 +5,7 @@
 \alias{as.linnet.sfnetwork}
 \title{Convert a sfnetwork into a linnet}
 \usage{
-\method{as.linnet}{sfnetwork}(X, ...)
+as.linnet.sfnetwork(X, ...)
 }
 \arguments{
 \item{X}{An object of class \code{\link{sfnetwork}} with a projected CRS.}


### PR DESCRIPTION
Following the discussion in #265, I think that the correct fix just requires specifying the package version as a character instead of a numeric. 

btw: @luukvdmeer, I added a lot of "noisy" commit to the develop branch (partially cleaned here) while trying to reproduce the CRAN error with GHA. Feel free to remove any change that you don't like