### PR TITLE
is.directed -> is_directed

### DIFF
--- a/tests/testthat/test_morphers.R
+++ b/tests/testthat/test_morphers.R
@@ -252,8 +252,8 @@ test_that("morphers return same network when there is no morphing
     suppressWarnings(ecount(convert(subd_u, to_spatial_subdivision)))
   )
   expect_equal(
-    is.directed(net_d),
-    is.directed(convert(net_d, to_spatial_directed))
+    is_directed(net_d),
+    is_directed(convert(net_d, to_spatial_directed))
   )
   expect_setequal(
     st_geometry(activate(net_l, "edges")),


### PR DESCRIPTION
is.directed is soft deprecated since igraph v2.0.0

``` r
igraph::is.directed
#> function (graph) 
#> {
#>     lifecycle::deprecate_soft("2.0.0", "is.directed()", "is_directed()")
#>     is_directed(graph = graph)
#> }
#> <bytecode: 0x000002514453abf8>
#> <environment: namespace:igraph>
```

<sup>Created on 2024-03-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
