### PR TITLE
Update min versions :couple:

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     sfheaders,
     stats,
     tibble,
-    tidygraph,
+    tidygraph (>= 1.3.0),
     tidyselect,
     units,
     utils


### PR DESCRIPTION
Unfortunately, I cannot install the v1.0 branch: 

```
==> Rcmd.exe INSTALL --preclean --no-multiarch --with-keep.source sfnetworks

* installing to library 'C:/Users/user/AppData/Local/R/win-library/4.3'
* installing *source* package 'sfnetworks' ...
** using staged installation
** R
** data
*** moving datasets to lazyload DB
** byte-compile and prepare package for lazy loading
Error: object 'get_edge_ids' is not exported by 'namespace:igraph'
Execution halted
ERROR: lazy loading failed for package 'sfnetworks'
* removing 'C:/Users/user/AppData/Local/R/win-library/4.3/sfnetworks'
* restoring previous 'C:/Users/user/AppData/Local/R/win-library/4.3/sfnetworks'

Exited with status 1.
```

The problem is that we are now using `igraph::get_edge_ids` which, according to [`igraph` NEWS file](https://cran.r-project.org/web/packages/igraph/news/news.html), was introduced in 2.1.0 (which is fairly recent). 

There is an analogous problem with `tidygraph` since we are using `tidygraph::unfocus` which was implemented in v1.3.0: https://cran.r-project.org/web/packages/tidygraph/news/news.html. 