### PR TITLE
feat: Compatibility with upcoming igraph 2.1.2

### DIFF
--- a/R/igraph.R
+++ b/R/igraph.R
@@ -1,0 +1,21 @@
+igraph_adjacent_vertices_offset <- new.env(parent = emptyenv())
+
+# An off-by-one error in igraph::adjacent_vertices() was fixed in igraph 2.1.2.
+get_igraph_adjacent_vertices_offset <- function() {
+  if (!is.null(igraph_adjacent_vertices_offset$offset)) {
+    return(igraph_adjacent_vertices_offset$offset)
+  }
+  opt <- igraph::igraph_opt("return.vs.es")
+  on.exit(igraph::igraph_options(return.vs.es = opt))
+  igraph::igraph_options(return.vs.es = FALSE)
+  test_graph <- igraph::make_graph(edges = c("a", "b"))
+  adjacent <- igraph::adjacent_vertices(
+    graph = test_graph,
+    v = "a",
+    mode = "out"
+  )
+  adjacent <- as.integer(adjacent)
+  offset <- 2L - adjacent
+  igraph_adjacent_vertices_offset$offset <- offset
+  offset
+}

--- a/R/morphers.R
+++ b/R/morphers.R
@@ -755,15 +755,15 @@ to_spatial_smooth = function(x,
       # --> The index of the edge that comes in to the pseudo node set.
       # --> The index of the non-pseudo node at the other end of that edge.
       # We'll call this the source node and source edge of the set.
-      # Note the + 1 since adjacent_vertices returns indices starting from 0.
-      source_node = adjacent_vertices(x, n_i, mode = "in")[[1]] + 1
+      source_node = adjacent_vertices(x, n_i, mode = "in")[[1]] +
+        get_igraph_adjacent_vertices_offset()
       source_edge = get.edge.ids(x, c(source_node, n_i))
       # Find the following:
       # --> The index of the edge that goes out of the pseudo node set.
       # --> The index of the non-pseudo node at the other end of that edge.
       # We'll call this the sink node and sink edge of the set.
-      # Note the + 1 since adjacent_vertices returns indices starting from 0.
-      sink_node = adjacent_vertices(x, n_o, mode = "out")[[1]] + 1
+      sink_node = adjacent_vertices(x, n_o, mode = "out")[[1]] +
+        get_igraph_adjacent_vertices_offset()
       sink_edge = get.edge.ids(x, c(n_o, sink_node))
       # List indices of all edges that will be merged into the replacement edge.
       edge_idxs = c(source_edge, E, sink_edge)
@@ -789,8 +789,8 @@ to_spatial_smooth = function(x,
       if (length(N) == 1) {
         # When we have a single pseudo node that forms a set:
         # --> It will be adjacent to both adjacent nodes of the set.
-        # Note the + 1 since adjacent_vertices returns indices starting from 0.
-        adjacent = adjacent_vertices(x, N)[[1]] + 1
+        adjacent = adjacent_vertices(x, N)[[1]] +
+          get_igraph_adjacent_vertices_offset()
         if (length(adjacent) == 1) {
           # If there is only one adjacent node to the pseudo node:
           # --> The two adjacent nodes of the set are the same node.
@@ -825,9 +825,9 @@ to_spatial_smooth = function(x,
         # We find them iteratively for the two boundary nodes of the set:
         # --> A boundary connects to one pseudo node and one non-pseudo node.
         # --> The non-pseudo node is the one not present in the pseudo set.
-        # Note the + 1 since adjacent_vertices returns indices starting from 0.
         get_set_neighbour = function(n) {
-          all = adjacent_vertices(x, n)[[1]] + 1
+          all = adjacent_vertices(x, n)[[1]] +
+            get_igraph_adjacent_vertices_offset()
           all[!(all %in% N)]
         }
         adjacent = do.call("c", lapply(N_b, get_set_neighbour))


### PR DESCRIPTION
@luukvdmeer: This is a hotfix on top of the currently released v0.6.4 to enable compatibility with the upcoming igraph release.

I can't easily test locally due to a broken GDAL (?) setup. The main compatibility code is borrowed from https://github.com/ropensci/targets/blob/f872e3afd96a832e62ad852e4068e77f75954d30/R/utils_igraph.R#L33, thanks @wlandau!

If you want to release this compatibility fix, perhaps as 0.6.5, continuity will be provided for CRAN users. I will ask CRAN to release igraph 2.1.2 tomorrow. Apologies for the short notice, this was a last-minute bugfix for igraph that had unanticipated consequences.

This PR doesn't cleanly apply to the main branch, but it looks like it can be ported.